### PR TITLE
improve db migrations

### DIFF
--- a/backend/cmd/user-service/app.go
+++ b/backend/cmd/user-service/app.go
@@ -36,9 +36,9 @@ func (a *app) shutdown(ctx context.Context) {
 	// TODO: log success
 }
 
-func (a *app) migrate(ctx context.Context) error {
+func (a *app) migrate(ctx context.Context, migrateDown bool) error {
 	log.Println("starting db migrations")
-	if err := database.Migrate(ctx, a.database, filesys, "migrations"); err != nil {
+	if err := database.Migrate(ctx, a.database, filesys, "migrations", migrateDown); err != nil {
 		return err
 	}
 

--- a/backend/cmd/user-service/main.go
+++ b/backend/cmd/user-service/main.go
@@ -28,7 +28,7 @@ func main() {
 	}
 
 	if cfg.MigrateMode { // run DB migrations and exit
-		if err := app.migrate(ctx); err != nil {
+		if err := app.migrate(ctx, cfg.MigrateDown); err != nil {
 			panic(err)
 		}
 

--- a/backend/internal/pkg/config/config.go
+++ b/backend/internal/pkg/config/config.go
@@ -16,6 +16,10 @@ type Config struct {
 	// command or as a server. This control is in place to facilitate applying any
 	// database schema changes required before the server is run.
 	MigrateMode bool `env:"MIGRATE_MODE" envDefault:"false"`
+	// MigrateDown controls whether the binary will apply the down migration instead
+	// of the up migration. This control is in place to facilitate rolling back database
+	// schema changes.
+	MigrateDown bool `env:"MIGRATE_DOWN" envDefault:"false"`
 	// StopIstioOnExit controls whether the binary will POST a quit message to the
 	// Istio sidecar on successful process exit.  This facilitats the use of the binary in
 	// k8s Jobs running with MigrateMode=true such that the Job will complete exit.


### PR DESCRIPTION
- add MigrateDown to Config struct
- implement migrate down

This change allows the binary to perform the down migration using the `MigrateDown` config