### PR TITLE
add render.yaml and Dockerfile for render deployment

### DIFF
--- a/backend/build/package/Dockerfile
+++ b/backend/build/package/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.23 as BUILDER
+
+# ARG BUILD_DIR
+
+WORKDIR /workspace
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+COPY . ./
+
+RUN CGO_ENABLED=0 go build -o /app ./cmd/user-service
+
+# Final stage with minimal dependencies
+FROM gcr.io/distroless/static
+
+COPY --from=BUILDER /app /app
+
+# Add default.conf to nginx configuration path
+# ENTRYPOINT ["/app"]
+CMD ["./app"]

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,21 @@
+services:
+  - name: user-service
+    type: web
+    plan: free
+    runtime: docker
+    rootDir: backend
+    branch: main
+    autoDeploy: true
+    region: oregon
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: tattoo-app-db
+          property: connectionString
+      - key: PORT
+        value: 8080
+
+databases:
+  - name: tattoo-app-db
+    plan: free
+    region: oregon


### PR DESCRIPTION
Adding `render.yaml` to configure service and database on Render. The `Dockerfile` is used to build the backend service.
