### PR TITLE
inject baseurls via env variables

### DIFF
--- a/frontend/tattooapp/.env.example
+++ b/frontend/tattooapp/.env.example
@@ -1,0 +1,3 @@
+# You need to create a .env file in the same directory which looks simlar to this
+USER_SERVICE_BASE_URL=https://dev.example.com
+ARTIST_SERVICE_BASE_URL=https://dev.example.com

--- a/frontend/tattooapp/.gitignore
+++ b/frontend/tattooapp/.gitignore
@@ -1,4 +1,5 @@
 # Miscellaneous
+.env
 *.class
 *.log
 *.pyc

--- a/frontend/tattooapp/lib/main.dart
+++ b/frontend/tattooapp/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:tattooapp/src/app/presentation/app_root.dart';
 
 void main() async {
@@ -10,6 +11,9 @@ void main() async {
     DeviceOrientation.portraitUp,
     DeviceOrientation.portraitDown,
   ]);
+
+  // Load environment variables from .env file
+  await dotenv.load(fileName: ".env");
 
   runApp(const ProviderScope(child: AppRoot()));
 }

--- a/frontend/tattooapp/pubspec.lock
+++ b/frontend/tattooapp/pubspec.lock
@@ -142,6 +142,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: b7c7be5cd9f6ef7a78429cabd2774d3c4af50e79cb2b7593e3d5d763ef95c61b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/frontend/tattooapp/pubspec.yaml
+++ b/frontend/tattooapp/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   device_info_plus: ^11.3.3
   url_launcher: ^6.3.1
   lottie: ^3.3.1
+  flutter_dotenv: ^5.2.1
 
 dev_dependencies:
   flutter_test:
@@ -66,6 +67,7 @@ flutter:
 
   # To add assets to your application, add an assets section, like this:
   assets:
+    - .env
     - assets/animations/splash_screen.json
     - assets/animations/loading.json
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
Using .env to inject baseurls into the service clients. Adding make targets to run `ngrok` and update the `.env` file with the public URLs for local development.
