### PR TITLE
fix bug with avatar url

### DIFF
--- a/backend/internal/pkg/models/user.go
+++ b/backend/internal/pkg/models/user.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"database/sql"
 	"time"
 )
 
@@ -16,7 +17,7 @@ type User struct {
 	Role      UserRole
 	FirstName string
 	LastName  string
-	AvatarUrl string
+	AvatarUrl sql.NullString
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }


### PR DESCRIPTION
Since the avatar url can be empty, we need to use sql.NullString to handle the case when the avatar url is not provided. This change ensures that the avatar url is stored correctly in the database and can be retrieved without issues.
