### PR TITLE
client frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,10 @@ update-env:
 
 	@USER_URL=$$(jq -r '.tunnels[] | select(.name=="user-service") | .public_url' tunnels.json) && \
 	ARTIST_URL=$$(jq -r '.tunnels[] | select(.name=="artist-service") | .public_url' tunnels.json) && \
+	CLIENT_URL=$$(jq -r '.tunnels[] | select(.name=="client-service") | .public_url' tunnels.json) && \
 	echo "USER_SERVICE_BASE_URL=$${USER_URL}" > $(ENV_FILE) && \
 	echo "ARTIST_SERVICE_BASE_URL=$${ARTIST_URL}" >> $(ENV_FILE) && \
+	echo "CLIENT_SERVICE_BASE_URL=$${CLIENT_URL}" >> $(ENV_FILE) && \
 	echo "✅ Updated .env file at $(ENV_FILE)" && \
 	cat $(ENV_FILE) && \
 	rm tunnels.json

--- a/frontend/tattooapp/.env.example
+++ b/frontend/tattooapp/.env.example
@@ -1,3 +1,4 @@
 # You need to create a .env file in the same directory which looks simlar to this
 USER_SERVICE_BASE_URL=https://dev.example.com
 ARTIST_SERVICE_BASE_URL=https://dev.example.com
+CLIENT_SERVICE_BASE_URL=https://dev.example.com

--- a/frontend/tattooapp/lib/src/app/presentation/app_root.dart
+++ b/frontend/tattooapp/lib/src/app/presentation/app_root.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tattooapp/src/core/theme/theme.dart';
 import 'package:tattooapp/src/app/presentation/splash_screen.dart';
-import 'package:tattooapp/src/features/onboarding/presentation/welcome_carousel_screen.dart';
+import 'package:tattooapp/src/app/presentation/welcome_carousel_screen.dart';
 import 'package:tattooapp/src/features/user/presentation/name_entry_screen.dart';
 import 'package:tattooapp/src/features/user/presentation/user_type_selection_screen.dart';
 import 'package:tattooapp/src/features/user/presentation/style_preference_screen.dart';
 import 'package:tattooapp/src/features/artist/presentation/artist_profile_entry_screen.dart';
+import 'package:tattooapp/src/features/client/presentation/client_profile_entry_screen.dart';
+import 'package:tattooapp/src/features/client/presentation/client_profile_screen.dart';
 import 'package:tattooapp/src/features/session/presentation/profile_redirect_screen.dart';
 import 'package:tattooapp/src/features/artist/presentation/artist_profile_screen.dart';
 
@@ -32,8 +34,9 @@ class AppRoot extends ConsumerWidget {
         '/user/type-selection': (_) => const UserTypeSelectionScreen(),
         '/user/style-preference': (_) => const StylePreferenceScreen(),
         '/artist/profile-entry': (_) => const ArtistProfileEntryScreen(),
+        '/client/profile-entry': (_) => const ClientProfileEntryScreen(),
         '/profile': (context) => const ProfileRedirectScreen(),
-        // '/profile/client': (context) => const ClientProfileScreen(),
+        '/profile/client': (context) => const ClientProfileScreen(),
         '/profile/artist': (context) => ArtistProfileScreen(),
       },
     );

--- a/frontend/tattooapp/lib/src/features/client/application/create_client_profile_use_case.dart
+++ b/frontend/tattooapp/lib/src/features/client/application/create_client_profile_use_case.dart
@@ -1,0 +1,22 @@
+import 'package:tattooapp/src/features/client/data/client_profiles_repository.dart';
+import 'package:tattooapp/src/features/client/domain/client_profile.dart';
+
+class CreateClientProfileUseCase {
+  final ClientProfilesRepository _clientProfilesRepository;
+
+  CreateClientProfileUseCase(this._clientProfilesRepository);
+
+  Future<void> execute({
+    required String accessToken,
+    required ClientProfile client,
+  }) async {
+    try {
+      await _clientProfilesRepository.createClientProfile(
+        accessToken: accessToken,
+        clientProfile: client.toProto(),
+      );
+    } catch (e) {
+      throw Exception('Failed to create artist profile: $e');
+    }
+  }
+}

--- a/frontend/tattooapp/lib/src/features/client/application/get_client_profile_use_case.dart
+++ b/frontend/tattooapp/lib/src/features/client/application/get_client_profile_use_case.dart
@@ -1,0 +1,22 @@
+import 'package:tattooapp/src/features/client/data/client_profiles_repository.dart';
+import 'package:tattooapp/src/features/client/domain/client_profile.dart';
+
+class GetClientProfileUseCase {
+  final ClientProfilesRepository _clientProfilesRepository;
+
+  GetClientProfileUseCase(this._clientProfilesRepository);
+
+  Future<ClientProfile> execute({
+    required String accessToken,
+    required String userId,
+  }) async {
+    try {
+      final protoClientProfile = await _clientProfilesRepository
+          .getClientProfile(accessToken: accessToken, userId: userId);
+
+      return ClientProfile.fromProto(protoClientProfile);
+    } catch (e) {
+      throw Exception('Failed to create artist profile: $e');
+    }
+  }
+}

--- a/frontend/tattooapp/lib/src/features/client/application/new_client_profile_state.dart
+++ b/frontend/tattooapp/lib/src/features/client/application/new_client_profile_state.dart
@@ -1,0 +1,17 @@
+import 'package:tattooapp/src/features/client/domain/client_profile.dart';
+
+class NewClientProfileState {
+  final String? location;
+
+  const NewClientProfileState({this.location});
+
+  NewClientProfileState copyWith({String? location}) {
+    return NewClientProfileState(location: location ?? this.location);
+  }
+
+  bool get isComplete => location != null;
+
+  ClientProfile toClientProfile(String userId) {
+    return ClientProfile(userId: userId, location: location!);
+  }
+}

--- a/frontend/tattooapp/lib/src/features/client/client_providers.dart
+++ b/frontend/tattooapp/lib/src/features/client/client_providers.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tattooapp/src/features/auth/auth_providers.dart';
+import 'package:tattooapp/src/features/client/data/client_service_client.dart';
+import 'package:tattooapp/src/features/client/data/client_profiles_repository.dart';
+import 'package:tattooapp/src/features/client/application/new_client_profile_state.dart';
+import 'package:tattooapp/src/features/client/application/create_client_profile_use_case.dart';
+import 'package:tattooapp/src/features/client/application/get_client_profile_use_case.dart';
+
+final clientServiceClientProvider = Provider((ref) {
+  return ClientServiceClientFactory.create();
+});
+
+final clientProfilesRepositoryProvider = Provider((ref) {
+  final client = ref.watch(clientServiceClientProvider);
+  return ClientProfilesRepository(client);
+});
+
+final createClientProfileUseCaseProvider = Provider((ref) {
+  final repo = ref.watch(clientProfilesRepositoryProvider);
+  return CreateClientProfileUseCase(repo);
+});
+
+final getClientProfileUseCaseProvider = Provider((ref) {
+  final repo = ref.watch(clientProfilesRepositoryProvider);
+  return GetClientProfileUseCase(repo);
+});
+
+// provides the current client profile
+final clientProfileProvider = FutureProvider((ref) async {
+  final getClientProfile = ref.read(getClientProfileUseCaseProvider);
+  final accessToken = ref.watch(accessTokenProvider);
+  final userId = ref.watch(auth0UserIdProvider);
+
+  if (accessToken == null) throw Exception('Missing accessToken');
+  if (userId == null) throw Exception('Missing id');
+
+  return await getClientProfile.execute(
+    accessToken: accessToken,
+    userId: userId,
+  );
+});
+
+// provides the given client profile
+final getClientProfileProvider = FutureProvider.family((
+  ref,
+  String userId,
+) async {
+  final getClientProfile = ref.read(getClientProfileUseCaseProvider);
+  final accessToken = ref.watch(accessTokenProvider);
+
+  if (accessToken == null) throw Exception('Missing accessToken');
+
+  return await getClientProfile.execute(
+    accessToken: accessToken,
+    userId: userId,
+  );
+});
+
+final class NewClientProfileStateNotifier
+    extends StateNotifier<NewClientProfileState> {
+  NewClientProfileStateNotifier() : super(const NewClientProfileState());
+
+  void update({required String location}) {
+    state = state.copyWith(location: location);
+  }
+
+  void clear() {
+    state = const NewClientProfileState();
+  }
+}
+
+final newClientProfileStateProvider =
+    StateNotifierProvider<NewClientProfileStateNotifier, NewClientProfileState>(
+      (ref) => NewClientProfileStateNotifier(),
+    );

--- a/frontend/tattooapp/lib/src/features/client/data/client_profiles_repository.dart
+++ b/frontend/tattooapp/lib/src/features/client/data/client_profiles_repository.dart
@@ -1,0 +1,35 @@
+import 'package:tattooapp/gen/dart/tattooapp/client/v1/client_service.connect.client.dart';
+import 'package:tattooapp/gen/dart/tattooapp/client/v1/client_service.pb.dart';
+import 'package:tattooapp/gen/dart/tattooapp/client/v1/client_profile.pb.dart';
+import 'package:tattooapp/src/core/utils/auth_headers.dart';
+
+class ClientProfilesRepository {
+  final ClientServiceClient _client;
+
+  ClientProfilesRepository(this._client);
+
+  Future<void> createClientProfile({
+    required String accessToken,
+    required ClientProfile clientProfile,
+  }) async {
+    await _client.createClientProfile(
+      CreateClientProfileRequest(
+        userId: clientProfile.userId,
+        location: clientProfile.location,
+      ),
+      headers: authHeaders(accessToken),
+    );
+  }
+
+  Future<ClientProfile> getClientProfile({
+    required String accessToken,
+    required String userId,
+  }) async {
+    final response = await _client.getClientProfile(
+      GetClientProfileRequest(userId: userId),
+      headers: authHeaders(accessToken),
+    );
+
+    return response.clientProfile;
+  }
+}

--- a/frontend/tattooapp/lib/src/features/client/data/client_service_client.dart
+++ b/frontend/tattooapp/lib/src/features/client/data/client_service_client.dart
@@ -1,0 +1,19 @@
+import 'package:connectrpc/http2.dart';
+import 'package:connectrpc/protobuf.dart';
+import 'package:connectrpc/protocol/connect.dart' as protocol;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:tattooapp/gen/dart/tattooapp/client/v1/client_service.connect.client.dart';
+
+final baseUrl = dotenv.env['CLIENT_SERVICE_BASE_URL'];
+
+class ClientServiceClientFactory {
+  static ClientServiceClient create() {
+    final transport = protocol.Transport(
+      baseUrl: baseUrl!,
+      codec: const ProtoCodec(),
+      httpClient: createHttpClient(),
+    );
+
+    return ClientServiceClient(transport);
+  }
+}

--- a/frontend/tattooapp/lib/src/features/client/domain/client_profile.dart
+++ b/frontend/tattooapp/lib/src/features/client/domain/client_profile.dart
@@ -1,0 +1,19 @@
+import 'package:tattooapp/gen/dart/tattooapp/client/v1/client_profile.pb.dart'
+    as proto;
+
+class ClientProfile {
+  final String userId;
+  final String location;
+
+  const ClientProfile({required this.userId, required this.location});
+
+  factory ClientProfile.fromProto(proto.ClientProfile client) {
+    return ClientProfile(userId: client.userId, location: client.location);
+  }
+}
+
+extension ClientProfileMapper on ClientProfile {
+  proto.ClientProfile toProto() {
+    return proto.ClientProfile(userId: userId, location: location);
+  }
+}

--- a/frontend/tattooapp/lib/src/features/client/presentation/client_profile_entry_screen.dart
+++ b/frontend/tattooapp/lib/src/features/client/presentation/client_profile_entry_screen.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tattooapp/src/features/user/user_providers.dart';
+import 'package:tattooapp/src/features/auth/auth_providers.dart';
+import 'package:tattooapp/src/features/client/client_providers.dart';
+
+class ClientProfileEntryScreen extends ConsumerStatefulWidget {
+  const ClientProfileEntryScreen({super.key});
+
+  @override
+  ConsumerState<ClientProfileEntryScreen> createState() =>
+      _ClientProfileEntryScreenState();
+}
+
+class _ClientProfileEntryScreenState
+    extends ConsumerState<ClientProfileEntryScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _locationController = TextEditingController();
+
+  void _onContinue() async {
+    if (_formKey.currentState?.validate() ?? false) {
+      final location = _locationController.text.trim();
+
+      ref
+          .read(newClientProfileStateProvider.notifier)
+          .update(location: location);
+
+      final clientProfileState = ref.read(newClientProfileStateProvider);
+      final userState = ref.read(newUserStateProvider);
+
+      // check if client profile state is complete
+      if (!clientProfileState.isComplete) {
+        // show error message
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Please complete all fields')),
+        );
+        return;
+      }
+
+      // get access token
+      final accessToken = ref.read(accessTokenProvider);
+      if (accessToken == null) {
+        // show error message
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Please login again')));
+        return;
+      }
+
+      await ref
+          .read(createUserUseCaseProvider)
+          .execute(accessToken: accessToken, user: userState.toUser());
+      await ref
+          .read(createClientProfileUseCaseProvider)
+          .execute(
+            accessToken: accessToken,
+            client: clientProfileState.toClientProfile(userState.toUser().id),
+          );
+
+      if (!mounted) return;
+      // navigate to client profile screen
+      Navigator.of(
+        context,
+      ).pushNamedAndRemoveUntil('/profile', (route) => false);
+    } else {
+      // show error message
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please complete all fields')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Your Location')),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Where are you located?',
+                style: theme.textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 24),
+              TextFormField(
+                controller: _locationController,
+                decoration: const InputDecoration(
+                  labelText: 'City, State',
+                  border: OutlineInputBorder(),
+                ),
+                validator:
+                    (value) =>
+                        (value == null || value.isEmpty)
+                            ? 'Please enter your location'
+                            : null,
+              ),
+              const Spacer(),
+              ElevatedButton(
+                onPressed: _onContinue,
+                child: const Text('Finish Signup'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/tattooapp/lib/src/features/client/presentation/client_profile_screen.dart
+++ b/frontend/tattooapp/lib/src/features/client/presentation/client_profile_screen.dart
@@ -1,0 +1,151 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tattooapp/src/features/client/client_providers.dart';
+import 'package:tattooapp/src/features/user/user_providers.dart';
+import 'package:tattooapp/src/features/auth/auth_providers.dart';
+import 'package:tattooapp/src/features/user/domain/user.dart';
+import 'package:tattooapp/src/features/user/domain/partial_user_update.dart';
+import 'package:tattooapp/src/core/widgets/editable_avatar.dart';
+import 'package:tattooapp/src/core/utils/cloudinary_upload.dart';
+import 'package:tattooapp/src/features/auth/presentation/widgets/logout_button.dart';
+
+class ClientProfileScreen extends ConsumerStatefulWidget {
+  const ClientProfileScreen({super.key});
+
+  @override
+  ConsumerState<ClientProfileScreen> createState() =>
+      _ClientProfileScreenState();
+}
+
+class _ClientProfileScreenState extends ConsumerState<ClientProfileScreen> {
+  File? _selectedAvatar;
+
+  String _styleLabel(TattooStyles style) {
+    switch (style) {
+      case TattooStyles.americanTraditional:
+        return 'American Traditional';
+      case TattooStyles.japaneseTraditional:
+        return 'Japanese Traditional';
+      case TattooStyles.realism:
+        return 'Realism';
+      case TattooStyles.watercolor:
+        return 'Watercolor';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final clientProfileAsync = ref.watch(clientProfileProvider);
+    final userAsync = ref.watch(userProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Client Profile')),
+      body: clientProfileAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, st) => Center(child: Text('Error: $e')),
+        data: (profile) {
+          return userAsync.when(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (e, st) => Center(child: Text('Error loading user: $e')),
+            data: (user) {
+              return Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    EditableAvatar(
+                      imageUrl: _selectedAvatar?.path ?? user.avatarUrl,
+                      onImageSelected: (file) async {
+                        setState(() {
+                          _selectedAvatar = file;
+                        });
+                        final user = ref.read(userProvider).value;
+                        if (user == null) return;
+
+                        final accessToken = ref.read(accessTokenProvider);
+                        if (accessToken == null) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('Please login again')),
+                          );
+                          return;
+                        }
+
+                        final updateUser = ref.read(updateUserUseCaseProvider);
+
+                        try {
+                          final avatarUrl = await uploadImageToCloudinary(
+                            file: file,
+                            cloudName: 'tattooapp',
+                            uploadPreset: 'tattooapp_unsigned',
+                          );
+
+                          await updateUser.execute(
+                            accessToken: accessToken,
+                            userId: user.id,
+                            originalUser: user,
+                            updatedUser: PartialUserUpdate(
+                              avatarUrl: avatarUrl,
+                            ),
+                          );
+
+                          // // Optionally: refresh the userProvider manually
+                          // ref.invalidate(getUserProvider(widget.userId));
+                        } catch (e) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text('Failed to upload avatar: $e'),
+                            ),
+                          );
+                        }
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      '${user.firstName} ${user.lastName}',
+                      style: Theme.of(context).textTheme.headlineMedium,
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(Icons.location_on_outlined),
+                        const SizedBox(width: 8),
+                        Text(profile.location ?? 'Unknown location'),
+                      ],
+                    ),
+                    if (user.stylePreferences.isNotEmpty) ...[
+                      const SizedBox(height: 24),
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          'Styles',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Wrap(
+                          spacing: 8,
+                          runSpacing: 8,
+                          children:
+                              user.stylePreferences.map((style) {
+                                return Chip(label: Text(_styleLabel(style)));
+                              }).toList(),
+                        ),
+                      ),
+                    ],
+                    const Spacer(),
+                    const LogoutButton(),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/frontend/tattooapp/lib/src/features/user/presentation/style_preference_screen.dart
+++ b/frontend/tattooapp/lib/src/features/user/presentation/style_preference_screen.dart
@@ -51,20 +51,11 @@ class _StylePreferenceScreenState extends ConsumerState<StylePreferenceScreen> {
 
     // check if user is artist
     if (userState.role == UserRole.artist) {
-      // navigate to artist profile entry screen
       Navigator.of(context).pushNamed('/artist/profile-entry');
       return;
     } else {
-      // create user
-      final user = userState.toUser();
-      await ref
-          .read(createUserUseCaseProvider)
-          .execute(accessToken: accessToken, user: user);
-
-      if (!mounted) return;
-      Navigator.of(
-        context,
-      ).pushNamedAndRemoveUntil('/profile', (route) => false);
+      Navigator.of(context).pushNamed('/client/profile-entry');
+      return;
     }
   }
 
@@ -80,8 +71,6 @@ class _StylePreferenceScreenState extends ConsumerState<StylePreferenceScreen> {
         isArtist
             ? 'What styles do you specialize in?'
             : 'What styles are you into?';
-
-    final button = isArtist ? 'Continue' : 'Finish Setup';
 
     return Scaffold(
       appBar: AppBar(title: const Text('Your Style Preferences')),
@@ -120,7 +109,7 @@ class _StylePreferenceScreenState extends ConsumerState<StylePreferenceScreen> {
             ),
             ElevatedButton(
               onPressed: _selectedStyles.isNotEmpty ? _onContinue : null,
-              child: Text(button),
+              child: const Text('Continue'),
             ),
           ],
         ),


### PR DESCRIPTION
- add client profile use case and state classes
- create client profiles repository and client service client
- add data model for client profile
- add screens for client onboarding and client profile
- add providers for client
- add routes for client screens
- update Makefile and .env to handle client service
- add route to client screen from style pref screen

Hooking up the frontend to the new client service. The onboarding flow now supports clients.
